### PR TITLE
Always return list of local file paths

### DIFF
--- a/a2e/A2e.py
+++ b/a2e/A2e.py
@@ -334,14 +334,13 @@ class A2e:
 
             if not force and os.path.exists(filepath):
                 self._print('File: {} already exists, skipping...'.format(filepath))
-                continue
-
-            try:
-                self._download(url, filepath)
-            except BadStatusCodeError as e:
-                self._print('Could not download file: {}'.format(filepath))
-                self._print(e)
-                continue
+            else:
+                try:
+                    self._download(url, filepath)
+                except BadStatusCodeError as e:
+                    self._print('Could not download file: {}'.format(filepath))
+                    self._print(e)
+                    continue
 
             downloaded_files.append(filepath)
         return downloaded_files


### PR DESCRIPTION
Affects output from from `A2e.download_files()` or `A2e.download_search()`. Currently, there is no other way to go from a list of available DAP files to a list of local files, which is stored within a specific directory structure.